### PR TITLE
fixing stream ending at the appropriate time

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,29 +1,37 @@
 /* jshint node: true */
 
 var through = require('through2');
+var eos = require('end-of-stream');
 
 module.exports = function MultiDest() {
     // get all streams from the args in an array
     var destinations = Array.prototype.slice.call(arguments);
+
     // get an output stream
-    var output = through.obj();
-    
-    function onData(data) {
-        // copy any data to all streams
-        destinations.forEach(function(dest){
-            dest.write(data);
-        });
-    }
-    
-    function onEnd() {
-        // end all streams
-        destinations.forEach(function(dest){
-            dest.end();
-        });
-    }
-    
-    output.on('data', onData);
-    output.on('end', onEnd);
-    
+    var output = through.obj(function onData(file, enc, cb) {
+      // copy any data to all streams
+      destinations.forEach(function(dest){
+          dest.write(file);
+      });
+
+      cb(null, file);
+    }, function onFlush(cb) {
+      var finishedCount = 0;
+
+      function onFinish() {
+        finishedCount += 1;
+
+        if (finishedCount === destinations.length) {
+          cb();
+        }
+      }
+
+      // end all streams
+      destinations.forEach(function(dest) {
+          eos(dest, onFinish);
+          dest.end();
+      });
+    });
+
     return output;
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-multistream",
   "version": "0.1.0",
-  "main": "./index.js",
+  "main": "index.js",
   "scripts": {
     "test": "node test.js",
     "coverage": "istanbul cover test.js"

--- a/package.json
+++ b/package.json
@@ -3,16 +3,19 @@
   "version": "0.1.0",
   "main": "index.js",
   "scripts": {
-    "test": "node test.js",
+    "test": "mocha",
     "coverage": "istanbul cover test.js"
   },
   "author": "Kiril Vatev <vatev.1@gmail.com>",
   "license": "ISC",
   "devDependencies": {
     "assert": "^1.3.0",
+    "async": "^2.5.0",
+    "chai": "^4.1.2",
     "codeclimate-test-reporter": "^0.1.0",
     "event-stream": "^3.3.1",
     "istanbul": "^0.3.18",
+    "mocha": "^3.5.3",
     "vinyl": "^0.5.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "vinyl": "^0.5.0"
   },
   "dependencies": {
+    "end-of-stream": "^1.4.0",
     "through2": "^2.0.0"
   },
   "repository": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -125,7 +125,6 @@ describe('[index]', function () {
             waitOrder('multi', multi)
         ], function (err) {
             expect(order).to.deep.equal(['out1', 'out2', 'multi']);
-            console.log(order);
             done(err);
         });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,35 @@
+/* jshint node: true, mocha: true */
+var expect = require('chai').expect;
+var es = require('event-stream');
+var File = require('vinyl');
+var async = require('async');
+
+var multistream = require('../');
+
+describe('[index]', function () {
+    var fakeData = 'llama';
+
+    it('works with stream data', function (done) {
+        var out1 = es.through();
+        var out2 = es.through();
+
+        var inputFile = new File({
+            contents: es.readArray([fakeData])
+        });
+
+        var multi = multistream(out1, out2);
+
+        async.parallel([
+            function (next) { out1.on('end', next); },
+            function (next) { out2.on('end', next); },
+            function (next) { multi.on('end', next); }
+        ], done);
+
+        multi.write(inputFile);
+        multi.end();
+    });
+
+    it('works with buffer data');
+
+    it('waits for all destination streams to finish before ending');
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,7 @@
 /* jshint node: true, mocha: true */
 var expect = require('chai').expect;
 var es = require('event-stream');
+var through = require('through2');
 var File = require('vinyl');
 var async = require('async');
 
@@ -8,6 +9,50 @@ var multistream = require('../');
 
 describe('[index]', function () {
     var fakeData = 'llama';
+
+    function slowStream(time) {
+        return through.obj(function (obj, enc, cb) {
+            setTimeout(function () {
+                cb(null, obj);
+            }, time || 1);
+        });
+    }
+
+    function wait(stream) {
+        return function (next) {
+            stream.pipe(es.wait(next));
+        };
+    }
+
+    function doMultiWrite(input, out1, out2) {
+        var multi = multistream(out1, out2);
+
+        setImmediate(function () {
+            multi.write(input);
+            multi.end();
+        });
+
+        return multi;
+    }
+
+    function test(input, out1, out2, done) {
+        var multi = doMultiWrite(input, out1, out2);
+        var data = [];
+
+        async.parallel([
+            wait(out1),
+            wait(out2),
+            wait(multi)
+        ], function (err) {
+            done(err, data);
+        });
+
+        multi.on('data', function (chunk) {
+            data.push(chunk);
+        });
+
+        return multi;
+    }
 
     it('works with stream data', function (done) {
         var out1 = es.through();
@@ -17,19 +62,71 @@ describe('[index]', function () {
             contents: es.readArray([fakeData])
         });
 
-        var multi = multistream(out1, out2);
+        test(inputFile, out1, out2, function (err, data) {
+            if (err) {
+                return done(err);
+            }
 
-        async.parallel([
-            function (next) { out1.on('end', next); },
-            function (next) { out2.on('end', next); },
-            function (next) { multi.on('end', next); }
-        ], done);
+            expect(data).to.have.lengthOf(1);
 
-        multi.write(inputFile);
-        multi.end();
+            var file = data[0];
+
+            expect(file).to.equal(inputFile);
+            expect(file.isBuffer()).to.equal(false);
+            expect(file.isStream()).to.equal(true);
+
+            done();
+        });
     });
 
-    it('works with buffer data');
+    it('works with buffer data', function (done) {
+        var out1 = es.through();
+        var out2 = es.through();
 
-    it('waits for all destination streams to finish before ending');
+        var inputFile = new File({ contents: new Buffer(fakeData) });
+
+        test(inputFile, out1, out2, function (err, data) {
+            if (err) {
+                return done(err);
+            }
+
+            expect(data).to.have.lengthOf(1);
+
+            var file = data[0];
+
+            expect(file).to.equal(inputFile);
+            expect(file.isBuffer()).to.equal(true);
+            expect(file.isStream()).to.equal(false);
+
+            done();
+        });
+    });
+
+    it('waits for all destination streams to finish before ending', function (done) {
+        var order = [];
+        var out1 = slowStream(1);
+        var out2 = slowStream(2);
+
+        function waitOrder(name, stream) {
+            return function (next) {
+                wait(stream)(function (err) {
+                    order.push(name);
+                    next(err);
+                });
+            };
+        }
+
+        var inputFile = new File({ contents: new Buffer(fakeData) });
+        var multi = doMultiWrite(inputFile, out1, out2);
+
+        async.parallel([
+            waitOrder('out1', out1),
+            waitOrder('out2', out2),
+            waitOrder('multi', multi)
+        ], function (err) {
+            expect(order).to.deep.equal(['out1', 'out2', 'multi']);
+            console.log(order);
+            done(err);
+        });
+    });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,6 +11,8 @@ var multistream = require('../');
 describe('[index]', function () {
     var fakeData = 'llama';
 
+    function noop () {}
+
     function slowStream(time) {
         return through.obj(function (obj, enc, cb) {
             setTimeout(function () {
@@ -21,7 +23,8 @@ describe('[index]', function () {
 
     function wait(stream) {
         return function (next) {
-            stream.pipe(es.wait(next));
+            stream.on('data', noop);
+            eos(stream, next);
         };
     }
 


### PR DESCRIPTION
Before, the multistream would end once it has read all the data, instead of when all the destination streams have flushed. This means that the stream could have finished while data was still in flight. Now, we wait until all of the data is flushed through the destination streams.

#2 